### PR TITLE
adding command to make nexus files

### DIFF
--- a/abvdoceanic_commands/nexus.py
+++ b/abvdoceanic_commands/nexus.py
@@ -1,0 +1,35 @@
+"""
+Write nexus file
+"""
+from lexibank_abvdoutliers import Dataset as Outliers
+from nexusmaker import load_cldf, NexusMaker, NexusMakerAscertained, NexusMakerAscertainedParameters
+
+
+def register(parser):
+    parser.add_argument("--output",
+        default="abvdoceanic.nex",
+        help="output file name")
+    parser.add_argument("--ascertainment",
+        default=None,
+        choices=[None, 'overall', 'word'],
+        help="set ascertainment mode")
+
+
+def run(args):
+    mdfile = Outliers().cldf_dir / "cldf-metadata.json"
+    args.log.info('loading %s' % mdfile)
+    records = list(load_cldf(mdfile, table='FormTable'))
+    args.log.info('writing nexus from %d records to %s using ascertainment=%s' % (
+        len(records), args.output, args.ascertainment
+    ))
+    
+    if args.ascertainment is None:
+        nex = NexusMaker(data=records)
+    elif args.ascertainment == 'overall':
+        nex = NexusMakerAscertained(data=records)
+    elif args.ascertainment == 'word':
+        nex = NexusMakerAscertainedParameters(data=records)
+    else:
+        raise ValueError("Unknown Ascertainment %s" % args.ascertainment)
+
+    nex.write(filename=args.output)

--- a/setup.py
+++ b/setup.py
@@ -24,5 +24,6 @@ setup(
     extras_require={"test": ["pytest-cldf"]},
     install_requires=[
         'pylexibank>=2.1',
+        'nexusmaker>=2.0.0',
     ]
 )


### PR DESCRIPTION
This PR adds a custom command to make a nexus file from the cldf dataset. Run as follows:

```shell
# basic nexus
cldfbench abvdoceanic.nexus  --output abvdoutliers.nex

# generate with ascertainment column for overall ascertainment correction.
cldfbench abvdoceanic.nexus --ascertainment overall --output abvdoutliers.asc.nex

# generate with ascertainment column per word for ascertainment correction on a word-by-word basis.
cldfbench abvdoceanic.nexus --ascertainment word --output abvdoutliers.words.nex
```

Note that this depends on the `[NexusMaker](github.com/SimonGreenhill/NexusMaker)` library, so you'll need to `pip install nexusmaker` or re-run `setup.py`.

